### PR TITLE
Defined the correct cursorColor for each theme

### DIFF
--- a/frappe.Xresources
+++ b/frappe.Xresources
@@ -1,5 +1,6 @@
 *background: #303446
 *foreground: #C6D0F5
+*cursorColor: #F2D5CF
 
 ! black
 *color0: #51576D

--- a/latte.Xresources
+++ b/latte.Xresources
@@ -1,5 +1,6 @@
 *background: #EFF1F5
 *foreground: #4C4F69
+*cursorColor: #DC8A78
 
 ! black
 *color0: #5C5F77

--- a/macchiato.Xresources
+++ b/macchiato.Xresources
@@ -1,5 +1,6 @@
 *background: #24273A
 *foreground: #CAD3F5
+*cursorColor: #F4DBD6
 
 ! black
 *color0: #494D64

--- a/mocha.Xresources
+++ b/mocha.Xresources
@@ -1,5 +1,6 @@
 *background: #1E1E2E
 *foreground: #CDD6F4
+*cursorColor: #F5E0DC
 
 ! black
 *color0: #45475A


### PR DESCRIPTION
Since the `cursorColor` isn't explicitly set, XTerm (and other terminals that may use this) uses the incorrect cursor color. This behavior is unlike the other configurations like [catppuccin/urxvt](https://github.com/catppuccin/urxvt/) or [catppuccin/st](https://github.com/catppuccin/st). I have added the correct `cursorColor` for each theme after cross-referencing it from other catppuccin terminal emulator configurations for correctness (for example, Rosewater `#dc8a78` for Latte, Rosewater `#f4dbd6` for Macchiato and so on and so forth).

Now the correct cursor colors show up. Here's XTerm with Catppuccin Macchiato for example:
![Screenshot from 2024-03-11 18-50-27](https://github.com/catppuccin/xresources/assets/22724578/d6639edd-65f9-4746-a714-e62eeef12166)

Compare with a screenshot from [catppuccin/nvim](https://github.com/catppuccin/nvim):
![252540902-932152df-ade9-4493-a764-4a7c6d3c9b3f](https://github.com/catppuccin/xresources/assets/22724578/f1c249a1-cad2-4abd-b6db-6bb05e03ec15)
